### PR TITLE
fix: avoid whitespace when value of identifier is falsy

### DIFF
--- a/src/classnames.macro.js
+++ b/src/classnames.macro.js
@@ -99,14 +99,14 @@ export default createMacro(({ babel, references: { default: paths } }) => {
       babel.types.isMemberExpression(node) ||
       babel.types.isIdentifier(node)
     ) {
-      return babel.types.binaryExpression(
-        "+",
-        babel.types.stringLiteral(" "),
-        babel.types.logicalExpression(
-          "||",
-          node,
-          babel.types.stringLiteral(""),
-        )
+      return babel.types.conditionalExpression(
+        node,
+        babel.types.binaryExpression(
+          "+",
+          babel.types.stringLiteral(" "),
+          node
+        ),
+        babel.types.stringLiteral("")
       )
     }
 

--- a/tests/classnames.macro.test.js
+++ b/tests/classnames.macro.test.js
@@ -20,7 +20,7 @@ test("variable", (t) => {
 
   const expected = stripIndent`
     const something = false;
-    const CLASS_NAMES = "py-2" + (" " + (something || ""));
+    const CLASS_NAMES = "py-2" + (something ? " " + something : "");
   `
 
   const output = run(input)
@@ -140,7 +140,7 @@ test("variables", (t) => {
   `
 
   const expected = stripIndent`
-    const CLASS_NAMES = "px-1" + (" " + (props.className || ""));
+    const CLASS_NAMES = "px-1" + (props.className ? " " + props.className : "");
   `
 
   const output = run(input)
@@ -161,7 +161,7 @@ test("mixed", (t) => {
   `
 
   const expected = stripIndent`
-    const CLASS_NAMES = "bar qux" + ((props.foo ? " foo fighters" : "") + ((props.baz ? " baz" : "") + (" " + (props.className || ""))));
+    const CLASS_NAMES = "bar qux" + ((props.foo ? " foo fighters" : "") + ((props.baz ? " baz" : "") + (props.className ? " " + props.className : "")));
   `
 
   const output = run(input)


### PR DESCRIPTION
I know white space is not significant in class names but it's a bit annoying 🙂